### PR TITLE
Remove white spaces from textarea

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,8 +316,7 @@ c_n & c_{n+1} & c_{n+2} & \dots & c_{2n}
     <option value="XITS">XITS (experimental)</option>
   </select> (see <a href="https://developer.mozilla.org/en-US/docs/Mozilla/MathML_Project/Fonts">Fonts for Mozilla's MathML engine</a>)
     </p>
-      <textarea id="input" cols="80" rows="5" onchange="update()" dir="ltr">
-      </textarea>
+      <textarea id="input" cols="80" rows="5" onchange="update()" dir="ltr"></textarea>
 
     <div id="output"></div>
 


### PR DESCRIPTION
With Firefox 30.0a1 (2014-02-11) the textarea was starting with
white spaces. They didn't break TeXZilla but I prefer start
with a empty textarea.
