### PR TITLE
Fix whitespaces in mtext

### DIFF
--- a/TeXZilla.jison
+++ b/TeXZilla.jison
@@ -251,7 +251,7 @@ tokenContent
        replace trailing/leading whitespace by no-break space so that people can
        write e.g. \text{ if }. We also collapse internal whitespace here.
        See https://github.com/fred-wang/TeXZilla/issues/25. */
-    $$ = $1.replace(/^\s+|\s+$/g, "\u00A0").replace(/\s+/g, " ");
+    $$ = $1.replace(/\s+/g, " ").replace(/^ | $/g, "\u00A0");
   }
   ;
 


### PR DESCRIPTION
This should close #32.

In Javascript regex [1], `\s` "Matches a single white space character, including
space, tab, form feed, line feed. Equivalent to [
\f\n\r\t\v​\u00a0\u1680​\u180e\u2000​\u2001\u2002​\u2003\u2004​\u2005\u2006​\u2007\u2008​\u2009\u200a​\u2028\u2029​​\u202f\u205f​\u3000]."

And in XML regex [2], `\s` is equivalent to [#x20\t\n\r].

Due the difference in the above definitions we choose to be compatible with
(La)TeX:
- "some  text" is the same as "some text",
- not allow non-break spaces (they will be replace by " ").

[1] https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions
[2] http://www.w3.org/TR/xmlschema-2/
