### PR TITLE
Fix prime symbol

### DIFF
--- a/TeXZilla.jison
+++ b/TeXZilla.jison
@@ -691,7 +691,7 @@ compoundTerm
   | closedTerm "^" closedTerm {
     $$ = newScript(false, $1, null, $3);
   }
-  | closedTerm OOP {
+  | closedTerm OPP {
     $$ = newScript(false, $1, null, newMo($2));
   }
   | closedTerm { $$ = $1; }
@@ -708,7 +708,6 @@ compoundTerm
     $$ = newScript(true, $1, null, $3);
   }
   | opm { $$ = $1; }
-  | OPP { $$ = newMo($1); }
   ;
 
 opm

--- a/unit-tests.js
+++ b/unit-tests.js
@@ -202,9 +202,9 @@ var tests = [
   /* char commands */
   [". - + \\# , : ! = ~ ; ? # ` *", '<math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mo>.</mo><mo>-</mo><mo>+</mo><mo>#</mo><mo>,</mo><mo>:</mo><mo>!</mo><mo>=</mo><mo stretchy="false">~</mo><mo>;</mo><mo>?</mo><mo>#</mo><mo>`</mo><mo>*</mo></mrow><annotation encoding="TeX">. - + \\# , : ! = ~ ; ? # ` *</annotation></semantics></math>'],
   /* primes */
-  ["\\prime ' '' ''' ''''", '<math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mo>′</mo><mo>′</mo><mo>″</mo><mo>‴</mo><mo>⁗</mo></mrow><annotation encoding="TeX">\\prime \' \'\' \'\'\' \'\'\'\'</annotation></semantics></math>'],
+  ["f\\prime f' f'' f''' f''''", '<math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><msup><mi>f</mi><mo>′</mo></msup><msup><mi>f</mi><mo>′</mo></msup><msup><mi>f</mi><mo>″</mo></msup><msup><mi>f</mi><mo>‴</mo></msup><msup><mi>f</mi><mo>⁗</mo></msup></mrow><annotation encoding="TeX">f\\prime f\' f\'\' f\'\'\' f\'\'\'\'</annotation></semantics></math>'],
   /* char commands */
-    ["\\omicron \\epsilon \\cdot", '<math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>ℴ</mi><mi>ϵ</mi><mo>⋅</mo></mrow><annotation encoding="TeX">\\omicron \\epsilon \\cdot</annotation></semantics></math>'],
+  ["\\omicron \\epsilon \\cdot", '<math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>ℴ</mi><mi>ϵ</mi><mo>⋅</mo></mrow><annotation encoding="TeX">\\omicron \\epsilon \\cdot</annotation></semantics></math>'],
 
   /* char commands */
   /* https://github.com/fred-wang/TeXZilla/issues/5 */


### PR DESCRIPTION
This PR should fix the conversion of `f'` in `<msup><mi>f</mi><mo>'</mo></msup>` instead of `<mi>f</mi><mo>'</mo>`.

For me don't make much sense in `'` be converted into `<mo>'</mo>` and because of it the rule for it was removed and the unit test change.
