### PR TITLE
Works as an npm package now

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
     { "name": "Frédéric Wang" }
   ],
   "files": ["TeXZilla.js", "npmbin.sh", "README.md"],
-  "bin": "npmbin.sh"
+  "bin": "npmbin.sh",
+  "main": "TeXZilla.js"
 }


### PR DESCRIPTION
By adding the main script in `package.json` we can require the
package from anywhere by doing `var texzilla = require('texzilla')`
as [recommended by npm](https://docs.npmjs.com/misc/developers#the-packagejson-file).

This is essential if we want to use this package with other node modules