### PR TITLE
Add citation of research paper to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Description
 -----------
 
 TeXZilla is a Javascript LaTeX-to-MathML converter compatible
-with Unicode. This is still a work in progress and things may change in the
+with Unicode. It has perfmored as the fastest state of the art LaTeX-To-MathML converter according to recent research in this field (see [[1](#references)]). This is still a work in progress and things may change in the
 future. Please report any bug you find to the
 [issue tracker](https://github.com/fred-wang/TeXZilla/issues?state=open).
 
@@ -49,3 +49,8 @@ To build TeXZilla, run the tests and generate the minified version:
       make minify
 
 Type `make help` for more commands.
+
+
+References
+------------------
+[1] _"Improving the Representation and Conversion of Mathematical Formulae by Considering their Textual Context"_ by M. Schubotz, et al. In: _Proceedings of the ACM/IEEE-CS Joint Conference on Digital Libraries (JCDL)_. Fort Worth, USA, June 2018. [DOI:10.1145/3197026.3197058](dx.doi.org/10.1145/3197026.3197058)


### PR DESCRIPTION
A benchmark testing in a scientific paper discovered that TeXZilla has performed as the best tool according to runtime performances. A pre-print of the paper can be found here: https://arxiv.org/pdf/1804.04956.pdf